### PR TITLE
fix deprecated argument URLField.verify_exists (had been removed in django 1.5)

### DIFF
--- a/cas_provider/models.py
+++ b/cas_provider/models.py
@@ -36,7 +36,7 @@ class BaseTicket(models.Model):
 
 class ServiceTicket(BaseTicket):
     user = models.ForeignKey(User, verbose_name=_('user'))
-    service = models.URLField(_('service'), verify_exists=False)
+    service = models.URLField(_('service'))
 
     prefix = 'ST'
 


### PR DESCRIPTION
The feature was deprecated in 1.3.1 due to intractable security and performance issues and will follow a slightly accelerated deprecation timeframe.
