### PR TITLE
A quick fix to solve Django 1.5 and 1.6 compatibility issues

### DIFF
--- a/cas_provider/models.py
+++ b/cas_provider/models.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from random import Random
@@ -35,8 +35,8 @@ class BaseTicket(models.Model):
 
 
 class ServiceTicket(BaseTicket):
-    user = models.ForeignKey(User, verbose_name=_('user'))
-    service = models.URLField(_('service'), verify_exists=False)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('user'))
+    service = models.URLField(_('service'))
 
     prefix = 'ST'
 

--- a/cas_provider/templates/cas/login.html
+++ b/cas_provider/templates/cas/login.html
@@ -5,7 +5,7 @@ Login
 {% endblock %}
 
 {% block content %}
-  <form action='{% url cas_login %}' method='post'>
+  <form action='{% url 'cas_login' %}' method='post'>
     <fieldset>
       <legend>Log in to your account</legend>
 	  {% csrf_token %}

--- a/cas_provider/urls.py
+++ b/cas_provider/urls.py
@@ -1,5 +1,8 @@
-from django.conf.urls.defaults import patterns, url
-
+try:
+    from django.conf.urls import patterns, url, include
+except ImportError:
+    # for Django version less then 1.4
+    from django.conf.urls.defaults import patterns, url, include
 
 urlpatterns = patterns('cas_provider.views',
     url(r'^login/?$', 'login', name='cas_login'),

--- a/cas_provider/views.py
+++ b/cas_provider/views.py
@@ -214,7 +214,7 @@ def generate_proxy_granting_ticket(pgt_url, ticket):
 
 
 def _cas2_proxy_success(pt):
-    return HttpResponse(proxy_success(pt))
+    return HttpResponse(proxy_success(pt), mimetype='text/xml')
 
 
 def _cas2_sucess_response(user, pgt=None, proxies=None):


### PR DESCRIPTION
There are a lot of forks on this app, but you looked like the one with the one in pypi so I thought I would direct this towards you.  This just makes a few minor changes to make the app Django 1.6 compatible (and keeps the older url style so it should still work with older versions), that I have seen in a lot of the other forks.

Feel free to ignore
