### PR TITLE
Allow using a different user model field for username passback

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,9 @@ CAS_AUTO_REDIRECT_AFTER_LOGOUT - If False (default behavior, specified in CAS pr
 after successful logout notification page will be shown. If it's True, after successful logout will
 be auto redirect back to service without any notification.
 
+CAS_USERNAME_FIELD - Specify the user model field to send back as the username. e.g. email instead
+of username. Default is username
+
 
 PROTOCOL DOCUMENTATION
 =====================

--- a/cas_provider/__init__.py
+++ b/cas_provider/__init__.py
@@ -7,6 +7,7 @@ _DEFAULTS = {
     'CAS_CUSTOM_ATTRIBUTES_CALLBACK': None,
     'CAS_CUSTOM_ATTRIBUTES_FORMATER': 'cas_provider.attribute_formatters.jasig',
     'CAS_AUTO_REDIRECT_AFTER_LOGOUT': False,
+    'CAS_USERNAME_FIELD': 'username'
 }
 
 for key, value in _DEFAULTS.iteritems():

--- a/cas_provider/views.py
+++ b/cas_provider/views.py
@@ -244,7 +244,7 @@ def auth_success_response(user, pgt, proxies):
     response = etree.Element(CAS + 'serviceResponse', nsmap=NSMAP)
     auth_success = etree.SubElement(response, CAS + 'authenticationSuccess')
     username = etree.SubElement(auth_success, CAS + 'user')
-    username.text = user.username
+    username.text = getattr(user, settings.CAS_USERNAME_FIELD)
 
     if settings.CAS_CUSTOM_ATTRIBUTES_CALLBACK:
         callback = get_callable(settings.CAS_CUSTOM_ATTRIBUTES_CALLBACK)


### PR DESCRIPTION
This allows the user field to be configuration if you wanted to use something like email, first name, last name, etc.
